### PR TITLE
setup.py: install cm-rgb-gui

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ setup(
     keywords = "rgb hid wraith",
     url = "http://github.com/gfduszynski/cm-rgb",
     packages=['cm_rgb'],
-    scripts=['scripts/cm-rgb-cli','scripts/cm-rgb-monitor'],
+    scripts=[
+        'scripts/cm-rgb-cli',
+        'scripts/cm-rgb-gui',
+        'scripts/cm-rgb-monitor'
+    ],
     long_description=read('README.md'),
     long_description_content_type="text/markdown",
     classifiers=[


### PR DESCRIPTION
Thank you for this very useful utility! I noticed that `cm-rgb-gui` is not installed. So this is a tiny PR that changes that.